### PR TITLE
Support unicode characters in lexer

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -9,8 +9,8 @@ import Prelude hiding ((.), id)
 
 import Control.Arrow
 import Control.Category
-import qualified Data.ByteString.Lazy.Char8 as B8
 import Data.Data (Data, Typeable)
+import qualified Data.Text.Lazy as TL
 import qualified Language.Sexp as Sexp
 import Language.SexpGrammar
 import Language.SexpGrammar.TH
@@ -69,11 +69,11 @@ parseExpr = parseSexp sexpIso
 genExpr :: Expr -> Either String Sexp
 genExpr = genSexp sexpIso
 
-expr :: B8.ByteString -> Expr
+expr :: TL.Text -> Expr
 expr = either error id . decode
 
-benchCases :: [(String, B8.ByteString)]
-benchCases = map (\a -> ("expression " ++ take 40 (B8.unpack a) ++ "...", a))
+benchCases :: [(String, TL.Text)]
+benchCases = map (\a -> ("expression " ++ take 40 (TL.unpack a) ++ "...", a))
   [ "(+ 1 20)"
   , "(+ (+ 2 20) 0)"
   , "(+ (+ 3 20) (+ 10 20))"

--- a/sexp-grammar.cabal
+++ b/sexp-grammar.cabal
@@ -40,6 +40,7 @@ library
     Data.InvertibleGrammar.Generic
     Data.InvertibleGrammar.TH
     Control.Monad.ContextError
+    Language.Sexp.LexerInterface
     Language.Sexp.Lexer
     Language.Sexp.Parser
     Language.Sexp.Token
@@ -71,13 +72,13 @@ test-suite sexp-grammar-test
   build-depends:
       QuickCheck
     , base
-    , bytestring
     , scientific
     , semigroups
     , sexp-grammar
     , tasty
     , tasty-hunit
     , tasty-quickcheck
+    , text
   main-is:           Main.hs
   hs-source-dirs:    test
   default-language:  Haskell2010
@@ -91,6 +92,7 @@ benchmark sexp-grammar-bench
     , scientific
     , semigroups
     , sexp-grammar
+    , text
   main-is:           Main.hs
   hs-source-dirs:    bench
   default-language:  Haskell2010

--- a/src/Language/Sexp.hs
+++ b/src/Language/Sexp.hs
@@ -20,7 +20,7 @@ module Language.Sexp
   , getPos
   ) where
 
-import qualified Data.ByteString.Lazy.Char8 as B8
+import qualified Data.Text.Lazy as TL
 
 import Language.Sexp.Types
 import Language.Sexp.Parser (parseSexp_, parseSexps_)
@@ -29,25 +29,25 @@ import Language.Sexp.Pretty (prettySexp, prettySexps)
 import Language.Sexp.Encode (encode)
 
 -- | Quickly decode a ByteString-formatted S-expression into Sexp structure
-decode :: B8.ByteString -> Either String Sexp
+decode :: TL.Text -> Either String Sexp
 decode = parseSexp "<str>"
 
 -- | Parse a ByteString-formatted S-expression into Sexp
 -- structure. Takes file name for better error messages.
-parseSexp :: FilePath -> B8.ByteString -> Either String Sexp
+parseSexp :: FilePath -> TL.Text -> Either String Sexp
 parseSexp fn inp = parseSexp_ (lexSexp (Position fn 1 0) inp)
 
 -- | Parse a ByteString-formatted sequence of S-expressions into list
 -- of Sexp structures. Takes file name for better error messages.
-parseSexps :: FilePath -> B8.ByteString -> Either String [Sexp]
+parseSexps :: FilePath -> TL.Text -> Either String [Sexp]
 parseSexps fn inp = parseSexps_ (lexSexp (Position fn 1 0) inp)
 
 -- | Parse a ByteString-formatted S-expression into Sexp
 -- structure. Takes file name for better error messages.
-parseSexp' :: Position -> B8.ByteString -> Either String Sexp
+parseSexp' :: Position -> TL.Text -> Either String Sexp
 parseSexp' pos inp = parseSexp_ (lexSexp pos inp)
 
 -- | Parse a ByteString-formatted sequence of S-expressions into list
 -- of Sexp structures. Takes file name for better error messages.
-parseSexps' :: Position -> B8.ByteString -> Either String [Sexp]
+parseSexps' :: Position -> TL.Text -> Either String [Sexp]
 parseSexps' pos inp = parseSexps_ (lexSexp pos inp)

--- a/src/Language/Sexp/LexerInterface.hs
+++ b/src/Language/Sexp/LexerInterface.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE BangPatterns   #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Sexp.LexerInterface
+  ( LineCol(..)
+  , AlexInput(..)
+  , mkAlexInput
+  -- Alex interfare
+  , alexInputPrevChar
+  , alexGetByte
+  ) where
+
+import Control.Applicative ((<|>))
+import Data.Char
+import Data.Maybe
+import qualified Data.Text.Lazy as TL
+import Data.Word (Word8)
+
+data LineCol = LineCol {-# UNPACK #-} !Int {-# UNPACK #-} !Int
+
+columnsInTab :: Int
+columnsInTab = 8
+
+advanceLineCol :: Char -> LineCol -> LineCol
+advanceLineCol '\n' (LineCol line _)   = LineCol (line + 1) 0
+advanceLineCol '\t' (LineCol line col) = LineCol line (col + columnsInTab)
+advanceLineCol _    (LineCol line col) = LineCol line (col + 1)
+
+data AlexInput = AlexInput
+  { aiInput    :: TL.Text
+  , aiPrevChar :: {-# UNPACK #-} !Char
+  , aiLineCol  :: !LineCol
+  }
+
+mkAlexInput :: TL.Text -> AlexInput
+mkAlexInput source = AlexInput
+  { aiInput    = stripBOM source
+  , aiPrevChar = '\n'
+  , aiLineCol  = initPos
+  }
+  where
+    initPos :: LineCol
+    initPos = LineCol 1 0
+    stripBOM :: TL.Text -> TL.Text
+    stripBOM xs =
+      fromMaybe xs $
+      TL.stripPrefix utf8BOM xs <|> TL.stripPrefix utf8BOM' xs
+    utf8BOM  = "\xFFEF"
+    utf8BOM' = "\xFEFF"
+
+-- Alex interface - functions usedby Alex
+alexInputPrevChar :: AlexInput -> Char
+alexInputPrevChar = aiPrevChar
+
+alexGetByte :: AlexInput -> Maybe (Word8, AlexInput)
+alexGetByte input@AlexInput {aiInput, aiLineCol} =
+  case TL.uncons aiInput of
+    Nothing      -> Nothing
+    Just (c, cs) -> Just $ encode c cs
+  where
+    encode :: Char -> TL.Text -> (Word8, AlexInput)
+    encode c cs = (b, input')
+      where
+        b :: Word8
+        b = fromIntegral $ ord $ fixChar c
+        input' :: AlexInput
+        input' = input
+          { aiInput    = cs
+          , aiPrevChar = c
+          , aiLineCol  = advanceLineCol c aiLineCol
+          }
+
+-- Translate unicode character into special symbol we taught Alex to recognize.
+fixChar :: Char -> Char
+fixChar c
+  -- Plain ascii case
+  | c <= '\x7f' = c
+  -- Unicode caset
+  | otherwise
+  = case generalCategory c of
+        Space -> space
+        _     -> nonSpaceUnicode
+  where
+    space           = '\x01'
+    nonSpaceUnicode = '\x02'

--- a/src/Language/Sexp/Pretty.hs
+++ b/src/Language/Sexp/Pretty.hs
@@ -52,13 +52,13 @@ instance Pretty Sexp where
   pretty = ppSexp
 
 -- | Pretty-print a Sexp to a Text
-prettySexp' :: Sexp -> Lazy.Text
-prettySexp' = displayT . renderPretty 0.75 79 . ppSexp
+prettySexp :: Sexp -> Lazy.Text
+prettySexp = displayT . renderPretty 0.75 79 . ppSexp
 
 -- | Pretty-print a Sexp to a ByteString
-prettySexp :: Sexp -> ByteString
-prettySexp = encodeUtf8 . prettySexp'
+prettySexp' :: Sexp -> ByteString
+prettySexp' = encodeUtf8 . prettySexp
 
 -- | Pretty-print a list of Sexps as a sequence of S-expressions to a ByteString
-prettySexps :: [Sexp] -> ByteString
-prettySexps = encodeUtf8 . displayT . renderPretty 0.75 79 . vcat . punctuate (line <> line) . map ppSexp
+prettySexps :: [Sexp] -> Lazy.Text
+prettySexps = displayT . renderPretty 0.75 79 . vcat . punctuate (line <> line) . map ppSexp

--- a/src/Language/Sexp/Types.hs
+++ b/src/Language/Sexp/Types.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveFoldable    #-}
-{-# LANGUAGE DeriveFunctor     #-}
-{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
 
 module Language.Sexp.Types

--- a/src/Language/SexpGrammar.hs
+++ b/src/Language/SexpGrammar.hs
@@ -102,6 +102,7 @@ module Language.SexpGrammar
   ) where
 
 import Data.ByteString.Lazy.Char8 (ByteString)
+import qualified Data.Text.Lazy as TL
 import Data.InvertibleGrammar
 import Data.InvertibleGrammar.Monad
 
@@ -132,12 +133,12 @@ genSexp g a =
 
 -- | Deserialize a value from a lazy 'ByteString'. The input must
 -- contain exactly one S-expression. Comments are ignored.
-decode :: SexpIso a => ByteString -> Either String a
+decode :: SexpIso a => TL.Text -> Either String a
 decode =
   decodeWith sexpIso
 
 -- | Like 'decode' but uses specified grammar.
-decodeWith :: SexpG a -> ByteString -> Either String a
+decodeWith :: SexpG a -> TL.Text -> Either String a
 decodeWith g input =
   Sexp.decode input >>= parseSexp g
 
@@ -159,21 +160,21 @@ encodeWith g =
 -- one S-expression. Unlike 'decode' it takes an additional argument
 -- with a file name which is being parsed. It is used for error
 -- messages.
-decodeNamed :: SexpIso a => FilePath -> ByteString -> Either String a
+decodeNamed :: SexpIso a => FilePath -> TL.Text -> Either String a
 decodeNamed fn =
   decodeNamedWith sexpIso fn
 
 -- | Like 'decodeNamed' but uses specified grammar.
-decodeNamedWith :: SexpG a -> FilePath -> ByteString -> Either String a
+decodeNamedWith :: SexpG a -> FilePath -> TL.Text -> Either String a
 decodeNamedWith g fn input =
   Sexp.parseSexp fn input >>= parseSexp g
 
 -- | Pretty-prints a value serialized to a lazy 'ByteString'.
-encodePretty :: SexpIso a => a -> Either String ByteString
+encodePretty :: SexpIso a => a -> Either String TL.Text
 encodePretty =
   encodePrettyWith sexpIso
 
 -- | Like 'encodePretty' but uses specified grammar.
-encodePrettyWith :: SexpG a -> a -> Either String ByteString
+encodePrettyWith :: SexpG a -> a -> Either String TL.Text
 encodePrettyWith g =
   fmap Sexp.prettySexp . genSexp g


### PR DESCRIPTION
This pull request addresses issue #3. I added support for unicode to lexer by dividing all characters into two broad categories: space and non-space characters. Space unicode characters are allowed whenever vanilla space is allowed. Non-space unicode characters are allowed everywhere else - they can be part of symbol and they can appear within lisp string. I think this design, even though it's unsophisticated, provides greatest flexibility in terms of what lexer accepts.