### PR TITLE
Allow text-2.0

### DIFF
--- a/invertible-grammar/invertible-grammar.cabal
+++ b/invertible-grammar/invertible-grammar.cabal
@@ -44,6 +44,6 @@ library
     , profunctors       >=4.4   && <5.7
     , semigroups        >=0.16  && <0.21
     , tagged            >=0.7   && <0.9
-    , template-haskell  >=2.9   && <2.18
+    , template-haskell  >=2.9   && <2.19
     , transformers      >=0.3   && <0.6
-    , text              >=1.2   && <1.3
+    , text              >=1.2   && <1.3 || >=2.0 && <2.1

--- a/sexp-grammar/sexp-grammar.cabal
+++ b/sexp-grammar/sexp-grammar.cabal
@@ -53,7 +53,7 @@ library
     , recursion-schemes  >=5.2   && <5.3
     , scientific         >=0.3.3 && <0.4
     , semigroups         >=0.16  && <0.21
-    , text               >=1.2   && <1.3
+    , text               >=1.2   && <1.3 || >=2.0 && <2.1
     , utf8-string        >=1.0   && <2.0
 
   build-tools: alex, happy


### PR DESCRIPTION
Tested with 
```cabal
packages:
  invertible-grammar/invertible-grammar.cabal
  sexp-grammar/sexp-grammar.cabal
constraints:
  text >= 2.0
```