### PR TITLE
Introduce datum comments

### DIFF
--- a/sexp-grammar/src/Language/Sexp/Lexer.x
+++ b/sexp-grammar/src/Language/Sexp/Lexer.x
@@ -54,34 +54,26 @@ $symsubseq  = [$syminitial \#\'\`\,]
 
 $whitespace+       ;
 ";" .*             ;
+"#;" / $allgraphic { const TokCommentIntro }
 
-"("                { just TokLParen   }
-")"                { just TokRParen   }
-"["                { just TokLBracket }
-"]"                { just TokRBracket }
-"{"                { just TokLBrace   }
-"}"                { just TokRBrace   }
+"("                { const TokLParen   }
+")"                { const TokRParen   }
+"["                { const TokLBracket }
+"]"                { const TokRBracket }
+"{"                { const TokLBrace   }
+"}"                { const TokRBrace   }
 
-"'" / $allgraphic  { just (TokPrefix Quote)    }
-"`" / $allgraphic  { just (TokPrefix Backtick) }
-",@" / $allgraphic { just (TokPrefix CommaAt)  }
-"," / $allgraphic  { just (TokPrefix Comma)    }
-"#" / $allgraphic  { just (TokPrefix Hash)     }
+"'"  / $allgraphic { const (TokPrefix Quote)    }
+"`"  / $allgraphic { const (TokPrefix Backtick) }
+",@" / $allgraphic { const (TokPrefix CommaAt)  }
+","  / $allgraphic { const (TokPrefix Comma)    }
+"#"  / $allgraphic { const (TokPrefix Hash)     }
 
-@number            { TokNumber  `via` readNum    }
-@symbol            { TokSymbol  `via` decode     }
-\" @string* \"     { TokString  `via` readString }
+@number            { TokNumber . readNum }
+@symbol            { TokSymbol . decode }
+\" @string* \"     { TokString . readString }
 
 {
-
-----------------------------------------------------------------------
--- Actions
-
-just :: Token -> AlexAction
-just tok _ = tok
-
-via :: (a -> Token) -> (ByteString -> a) -> AlexAction
-via ftok f = ftok . f
 
 ----------------------------------------------------------------------
 -- Decoders

--- a/sexp-grammar/src/Language/Sexp/Token.hs
+++ b/sexp-grammar/src/Language/Sexp/Token.hs
@@ -31,6 +31,7 @@ data Token
   | TokRBracket        -- ]
   | TokLBrace          -- {
   | TokRBrace          -- }
+  | TokCommentIntro    -- #;
   | TokPrefix  { getPrefix  :: !Prefix }      -- e.g. a quote in '(foo bar)
   | TokNumber  { getNumber  :: !Scientific }  -- 42.0, -1.0, 3.14, -1e10
   | TokString  { getString  :: !Text }        -- "foo", "", "hello world"
@@ -40,18 +41,19 @@ data Token
     deriving (Show, Eq)
 
 instance Pretty Token where
-  pretty TokLParen      = "left paren '('"
-  pretty TokRParen      = "right paren ')'"
-  pretty TokLBracket    = "left bracket '['"
-  pretty TokRBracket    = "right bracket '['"
-  pretty TokLBrace      = "left brace '{'"
-  pretty TokRBrace      = "right brace '}'"
-  pretty (TokPrefix c)  = "modifier" <+> pretty (show c)
-  pretty (TokSymbol s)  = "symbol" <+> squotes (pretty s) <> squote
-  pretty (TokNumber n)  = "number" <+> pretty (show n)
-  pretty (TokString s)  = "string" <+> pretty (show s)
-  pretty (TokUnknown u) = "unrecognized" <+> pretty u <> "..."
-  pretty TokEOF         = "end of file"
+  pretty TokLParen       = "left paren '('"
+  pretty TokRParen       = "right paren ')'"
+  pretty TokLBracket     = "left bracket '['"
+  pretty TokRBracket     = "right bracket '['"
+  pretty TokLBrace       = "left brace '{'"
+  pretty TokRBrace       = "right brace '}'"
+  pretty TokCommentIntro = "datum comment"
+  pretty (TokPrefix c)   = "modifier" <+> pretty (show c)
+  pretty (TokSymbol s)   = "symbol" <+> squotes (pretty s) <> squote
+  pretty (TokNumber n)   = "number" <+> pretty (show n)
+  pretty (TokString s)   = "string" <+> pretty (show s)
+  pretty (TokUnknown u)  = "unrecognized" <+> pretty u <> "..."
+  pretty TokEOF          = "end of file"
 
 
 newtype DText = DText (TL.Text -> TL.Text)

--- a/sexp-grammar/test/Main.hs
+++ b/sexp-grammar/test/Main.hs
@@ -358,6 +358,9 @@ lexerParserTests = testGroup "Sexp lexer/parser tests"
   , testCase "keyword" $
       parseSexp' ":foo"
       `sexpEq` Right (Symbol ":foo")
+  , testCase "datum comment" $
+      parseSexp' "(three #;(not four) element list)"
+      `sexpEq` Right (ParenList [Symbol "three", Symbol "element", Symbol "list"])
   ]
 
 


### PR DESCRIPTION
Introduces datum comments `#;`.

The following list:
```
(three #;(not four) element list)
```

Is parsed as:
```
(three element list)
```

Partially fixes #24 -- attn. @lortabac