### PR TITLE
Add instance Eq (SexpF a)

### DIFF
--- a/sexp-grammar/src/Language/Sexp/Types.hs
+++ b/sexp-grammar/src/Language/Sexp/Types.hs
@@ -115,6 +115,9 @@ data SexpF e
   | ModifiedF    !Prefix e
     deriving (Functor, Foldable, Traversable, Generic)
 
+instance Eq a => Eq (SexpF a) where
+  (==) = liftEq (==)
+
 instance Eq1 SexpF where
   liftEq eq = go
     where


### PR DESCRIPTION
It does not harm and provides compatibility with a [CLC proposal](https://github.com/haskell/core-libraries-committee/issues/10) to make `forall a. Eq a => Eq (f a)` a superclass of `Eq1 f`.