### PR TITLE
Support mtl-2.3

### DIFF
--- a/invertible-grammar/invertible-grammar.cabal
+++ b/invertible-grammar/invertible-grammar.cabal
@@ -39,7 +39,7 @@ library
       base              >=4.8   && <5.0
     , bifunctors        >=4.2   && <5.6
     , containers        >=0.5.5 && <0.7
-    , mtl               >=2.1   && <2.3
+    , mtl               >=2.1   && <2.4
     , prettyprinter     >=1     && <1.8
     , profunctors       >=4.4   && <5.7
     , semigroups        >=0.16  && <0.21


### PR DESCRIPTION
Tested with `cabal build all --constraint 'mtl >= 2.3'`. 

Could we please have a release once merged?