### PR TITLE
Allow template-haskell-2.19

### DIFF
--- a/invertible-grammar/invertible-grammar.cabal
+++ b/invertible-grammar/invertible-grammar.cabal
@@ -44,6 +44,6 @@ library
     , profunctors       >=4.4   && <5.7
     , semigroups        >=0.16  && <0.21
     , tagged            >=0.7   && <0.9
-    , template-haskell  >=2.9   && <2.19
+    , template-haskell  >=2.9   && <2.20
     , transformers      >=0.3   && <0.6
     , text              >=1.2   && <1.3 || >=2.0 && <2.1


### PR DESCRIPTION
As a Hackage trustee I made a matching revision: https://hackage.haskell.org/package/invertible-grammar-0.1.3.2/revisions/