### PR TITLE
Support deepseq-1.5 and other version bumps

### DIFF
--- a/invertible-grammar/invertible-grammar.cabal
+++ b/invertible-grammar/invertible-grammar.cabal
@@ -38,12 +38,12 @@ library
   build-depends:
       base              >=4.11  && <5.0
     , bifunctors        >=4.2   && <6.0
-    , containers        >=0.5.5 && <0.7
+    , containers        >=0.5.5 && <0.8
     , mtl               >=2.2   && <2.4
     , prettyprinter     >=1.7   && <2.0
     , profunctors       >=4.4   && <5.7
     , semigroups        >=0.16  && <0.21
     , tagged            >=0.7   && <0.9
-    , template-haskell  >=2.9   && <2.21
+    , template-haskell  >=2.9   && <2.22
     , transformers      >=0.3   && <0.7
-    , text              >=1.2   && <1.3 || >=2.0 && <2.1
+    , text              >=1.2   && <1.3 || >=2.0 && <2.2

--- a/sexp-grammar/sexp-grammar.cabal
+++ b/sexp-grammar/sexp-grammar.cabal
@@ -44,8 +44,8 @@ library
   build-depends:
       array              >=0.5   && <0.6
     , base               >=4.11  && <5.0
-    , bytestring         >=0.10  && <0.12
-    , containers         >=0.5.5 && <0.7
+    , bytestring         >=0.10  && <0.13
+    , containers         >=0.5.5 && <0.8
     , data-fix           >=0.3   && <0.4
     , deepseq            >=1.4.3 && <2.0
     , invertible-grammar >=0.1.3 && <0.2
@@ -53,7 +53,7 @@ library
     , recursion-schemes  >=5.2   && <5.3
     , scientific         >=0.3.3 && <0.4
     , semigroups         >=0.16  && <0.21
-    , text               >=1.2   && <1.3 || >=2.0 && <2.1
+    , text               >=1.2   && <1.3 || >=2.0 && <2.2
     , utf8-string        >=1.0   && <2.0
 
   build-tools: alex, happy

--- a/sexp-grammar/src/Language/Sexp/Types.hs
+++ b/sexp-grammar/src/Language/Sexp/Types.hs
@@ -65,6 +65,8 @@ instance Bifunctor LocatedBy where
 instance (Eq p) => Eq1 (LocatedBy p) where
   liftEq eq (p :< a) (q :< b) = p == q && a `eq` b
 
+instance (NFData p, NFData e) => NFData (LocatedBy p e)
+
 instance NFData p => NFData1 (LocatedBy p) where
   liftRnf f (p :< a) = rnf p `seq` f a
 
@@ -126,6 +128,8 @@ instance Eq1 SexpF where
 instance NFData Atom
 
 instance NFData Position
+
+instance NFData e => NFData (SexpF e)
 
 instance NFData1 SexpF where
   liftRnf f = \case


### PR DESCRIPTION
`deepseq-1.5` made `NFData` a superclass of `NFData1`: https://hackage.haskell.org/package/deepseq-1.5.0.0/docs/Control-DeepSeq.html#t:NFData1